### PR TITLE
Remove entry.sh from ARM image to improve ctrl-c handling

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -2,4 +2,5 @@ FROM hypriot/rpi-node:7.4.0-slim
 
 WORKDIR /code
 COPY tmp/ /code
+ENTRYPOINT []
 CMD ["node", "bin/app.js"]


### PR DESCRIPTION
On ARM ctrl+c does not work witout `-it` flag.
So we try to remove the `ENTRYPOINT` from the Resin base image.
