### PR TITLE
Create alpine images

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM node:7.4.0-slim
+FROM node:6.10.0-alpine
 
 WORKDIR /code
 COPY tmp /code

--- a/Dockerfile.amd64-build
+++ b/Dockerfile.amd64-build
@@ -1,4 +1,4 @@
-FROM node:7.4.0
+FROM node:6.10.0
 
 WORKDIR /code
 COPY package.json /code

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,6 +1,5 @@
-FROM hypriot/rpi-node:7.4.0-slim
+FROM hypriot/rpi-node:6.10.0-alpine
 
 WORKDIR /code
 COPY tmp/ /code
-ENTRYPOINT []
 CMD ["node", "bin/app.js"]

--- a/Dockerfile.arm-build
+++ b/Dockerfile.arm-build
@@ -1,4 +1,4 @@
-FROM hypriot/rpi-node:7.4.0
+FROM hypriot/rpi-node:6.10.0
 
 WORKDIR /code
 COPY package.json /code

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+set -e
+
 if [ $ARCH != "amd64" ]; then
   # prepare qemu
-  docker run --rm --privileged multiarch/qemu-user-static:register --reset
+  docker run --rm --privileged hypriot/qemu-register
 fi
 
 if [ -d tmp ]; then

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ $ARCH != "amd64" ]; then
   # prepare qemu
-  docker run --rm --privileged hypriot/qemu-register
+  docker run --rm --privileged multiarch/qemu-user-static:register --reset
 fi
 
 if [ -d tmp ]; then


### PR DESCRIPTION
Switch to Node.js 6.10.0 LTS in Alpine to create smaller images.
